### PR TITLE
Allow write and register lengths to differ

### DIFF
--- a/uModbus/common.py
+++ b/uModbus/common.py
@@ -283,6 +283,7 @@ class _ValueRegisters():
             end = index.stop
             if end is None:
                 end = len(self)
+            end = min(end, start + len(value))
 
             for i in range(start, end):
                 self._set_value(i, value[i-start])


### PR DESCRIPTION
Allows the length of addressed registers to differ from the values being set

```py
mb_server.input_registers[0:55] = [1, 2, 3, 4] # Now allow value list to be shorter than register bounds

```